### PR TITLE
Release the image reference in the OSX implementation

### DIFF
--- a/src/osx/prtscn_osx.mm
+++ b/src/osx/prtscn_osx.mm
@@ -35,4 +35,5 @@ void getScreen(const int x, const int y, int W, int H, const char* path) {
 	CGRect rect = CGRectMake(x, y, W, H);
 	CGImageRef image_ref = CGDisplayCreateImageForRect(CGMainDisplayID(), rect);
 	CGImageWriteToFile(image_ref, [NSString stringWithUTF8String:path]);
+	CGImageRelease(image_ref);
 }


### PR DESCRIPTION
Fixes #3

Call the CGImageRelease() to release the image reference after saving the data to a file